### PR TITLE
Add AI-7 HyperAtlas deployment links and gates

### DIFF
--- a/institutional_hyperatlas/DEPLOYMENT_LINKS.md
+++ b/institutional_hyperatlas/DEPLOYMENT_LINKS.md
@@ -1,0 +1,34 @@
+# AI-7 QC-CA HyperAtlas Deployment Links
+
+This file indexes the reviewable deployment surfaces for the AI-7 Québec-Canada Institutional HyperAtlas.
+
+## Canonical seed
+
+- Main PR: https://github.com/Tristan-TM-Poly/Tristan_Tardif-Morency_TFUG/pull/14
+- Module path: `institutional_hyperatlas/top_64x64x64x64/`
+- Tensor size: `64^4 = 16,777,216` candidate opportunity hyperedges.
+
+## Propagation issues
+
+- TFUGA-AI7-TRISTAN2: https://github.com/Tristan-TM-Poly/TFUGA-AI7-TRISTAN2/issues/1
+- TTM-TFUGA-AI7-TRISTAN2: https://github.com/Tristan-TM-Poly/TTM-TFUGA-AI7-TRISTAN2/issues/1
+- PEFA-FractalEnergySystem: https://github.com/Tristan-TM-Poly/PEFA-FractalEnergySystem/issues/1
+- TFUGAG mirror: https://github.com/Tristan-TM-Poly/Tristan_Tardif-Morency_TFUGAG/issues/1
+- TFACC audit: https://github.com/Tristan-TM-Poly/TFACC/issues/1
+- Web and game surface: https://github.com/Tristan-TM-Poly/Tristan_Tardif-Morency_TFUG/issues/15
+
+## Promotion rule
+
+`Promote(edge) = 1 iff Score > theta and PrivacyOK and LicenseOK and HumanReviewOK`.
+
+## Gates
+
+- Keep changes reviewable.
+- Keep deployments manual until checks pass.
+- Keep repository changes reversible.
+- Keep public outputs institution-level unless reviewed.
+- Keep PR #14 unmerged until mixed Vercel status is resolved or waived.
+
+## Next best PR
+
+`schema validation + privacy gate + license gate + CI test`.

--- a/institutional_hyperatlas/LAUNCH_OFFICIEL.md
+++ b/institutional_hyperatlas/LAUNCH_OFFICIEL.md
@@ -1,0 +1,64 @@
+# Lancement officiel AI-7 Québec-Canada Institutional HyperAtlas
+
+Statut: lancement officiel en mode public preview gouverné.
+
+## Noyau lancé
+
+AI-7 Québec-Canada Institutional HyperAtlas est lancé comme atlas institutionnel gouverné pour relier:
+
+- institutions et sources publiques,
+- défis réels Québec-Canada,
+- capacités AI-7 / TFUGA,
+- actions de gouvernance,
+- prototypes et collaborations vérifiables.
+
+Le générateur canonique Top 64^4 est publié via PR #14:
+
+https://github.com/Tristan-TM-Poly/Tristan_Tardif-Morency_TFUG/pull/14
+
+## Équation canonique
+
+```text
+Opportunity(a,b,c,d) = InstitutionSource[a] ⊗ Challenge[b] ⊗ Capability[c] ⊗ Action[d]
+```
+
+```text
+64^4 = 16,777,216 candidate opportunity hyperedges
+```
+
+## Règle de promotion
+
+```text
+Promote(edge) = 1 iff Score > theta and PrivacyOK and LicenseOK and HumanReviewOK
+```
+
+## Surfaces actives
+
+- PR #14: générateur Top 64^4.
+- PR #16: deployment links, privacy gate, license gate, validation runbook.
+- Issues de propagation: AI-7 repo, TTM seed, PEFA energy-water-climate, TFUGAG mirror, TFACC audit, web/game/cloud roadmap.
+- Drive governance document: index stratégique et gouvernance documentaire.
+- Daily review: surveillance continue des blocages et prochaines actions.
+
+## Garde-fous du lancement
+
+- Pas de scraping non validé.
+- Pas de collecte de données personnelles.
+- Pas d'outreach automatique.
+- Pas de secrets en dépôt.
+- Pas de déploiement cloud production sans validation humaine.
+- Pas de merge si les checks requis sont en échec ou ambigus.
+
+## Statut de production
+
+Ce lancement est officiel comme public preview gouverné. La production complète attend:
+
+1. résolution ou isolation du statut Vercel en échec,
+2. tests CI locaux no-network,
+3. validation de schéma,
+4. gates privacy/licence automatisés,
+5. revue humaine.
+
+## Phrase canonique
+
+AI-7 Québec-Canada HyperAtlas transforme les institutions, données publiques, défis et capacités en chemins vérifiables vers des prototypes utiles.

--- a/institutional_hyperatlas/VALIDATION_RUNBOOK.md
+++ b/institutional_hyperatlas/VALIDATION_RUNBOOK.md
@@ -1,0 +1,31 @@
+# AI-7 Institutional HyperAtlas Validation Runbook
+
+This runbook defines the safe validation path for the Québec-Canada Institutional HyperAtlas.
+
+## Local checks
+
+Run gates on any JSON records before promotion:
+
+```bash
+python institutional_hyperatlas/gates/privacy_gate.py path/to/records.json
+python institutional_hyperatlas/gates/license_gate.py path/to/records.json
+```
+
+## Promotion checklist
+
+- Source exists.
+- Licence or usage terms are known.
+- Provenance is stored.
+- Record is institution-level by default.
+- Personal-data flags are reviewed before use.
+- Outreach is manual-review only.
+- No secrets are present.
+- Cloud deployment is manual and reversible.
+
+## PR #14 blocker
+
+The Top 64^4 seed PR should not be merged into main until mixed Vercel status is resolved or explicitly reviewed.
+
+## Next CI step
+
+Add a workflow that runs only schema and gate tests. It must not fetch remote data, publish artifacts, or deploy cloud resources.

--- a/institutional_hyperatlas/examples/safe_sample_records.json
+++ b/institutional_hyperatlas/examples/safe_sample_records.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "org:qc:source:donnees_quebec",
+    "name": "Données Québec",
+    "type": "Dataset",
+    "jurisdiction": "Québec",
+    "privacy_level": "dataset_metadata",
+    "contact_policy": "no_outreach",
+    "canon_status": "seed",
+    "sources": [
+      {
+        "url": "https://www.donneesquebec.ca/",
+        "license": "official open data portal metadata, dataset licences vary",
+        "retrieved_at": "2026-04-28",
+        "confidence": 0.9
+      }
+    ]
+  },
+  {
+    "id": "org:qc:university:polytechnique_montreal",
+    "name": "Polytechnique Montréal",
+    "type": "University",
+    "jurisdiction": "Québec",
+    "privacy_level": "institutional",
+    "contact_policy": "manual_review_required",
+    "canon_status": "seed",
+    "sources": [
+      {
+        "url": "https://www.quebec.ca/en/education/university/studying/list-universities",
+        "license": "public institutional metadata",
+        "retrieved_at": "2026-04-28",
+        "confidence": 0.95
+      }
+    ]
+  }
+]

--- a/institutional_hyperatlas/gates/license_gate.py
+++ b/institutional_hyperatlas/gates/license_gate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Minimal licence gate for AI-7 Institutional HyperAtlas records."""
+import json
+import sys
+from pathlib import Path
+
+BAD = {"", "unknown", "unclear", "none", "n/a", "varies", "varies by dataset"}
+
+
+def scan_record(record):
+    flags = []
+    sources = record.get("sources", [])
+    if not sources:
+        flags.append("missing_sources")
+    for i, src in enumerate(sources):
+        licence = str(src.get("license", "")).strip().lower()
+        if licence in BAD:
+            flags.append(f"source_{i}_unclear_license")
+        if not src.get("url"):
+            flags.append(f"source_{i}_missing_url")
+        if not src.get("retrieved_at"):
+            flags.append(f"source_{i}_missing_retrieved_at")
+    return flags
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: license_gate.py <records.json>", file=sys.stderr)
+        return 2
+    records = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    if isinstance(records, dict):
+        records = [records]
+    findings = []
+    for idx, record in enumerate(records):
+        flags = scan_record(record)
+        if flags:
+            findings.append({"index": idx, "id": record.get("id"), "flags": flags})
+    result = {"passed": not findings, "findings": findings}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/institutional_hyperatlas/gates/privacy_gate.py
+++ b/institutional_hyperatlas/gates/privacy_gate.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Minimal privacy gate for AI-7 Institutional HyperAtlas records.
+
+This gate is intentionally conservative. It rejects records that look like
+people-level data unless they have been explicitly marked for manual review.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_RE = re.compile(r"(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?){2}\d{4}")
+PERSON_KEYS = {"person", "employee", "staff", "email", "phone", "linkedin", "contact_name"}
+
+
+def scan_record(record):
+    text = json.dumps(record, ensure_ascii=False).lower()
+    flags = []
+    if EMAIL_RE.search(text):
+        flags.append("email_detected")
+    if PHONE_RE.search(text):
+        flags.append("phone_detected")
+    if any(k in text for k in PERSON_KEYS):
+        flags.append("person_level_keyword")
+    privacy_level = record.get("privacy_level", "")
+    if privacy_level == "contains_personal_data_reject_or_minimize":
+        flags.append("explicit_personal_data_level")
+    return flags
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: privacy_gate.py <records.json>", file=sys.stderr)
+        return 2
+    path = Path(sys.argv[1])
+    records = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(records, dict):
+        records = [records]
+    findings = []
+    for idx, record in enumerate(records):
+        flags = scan_record(record)
+        if flags:
+            findings.append({"index": idx, "id": record.get("id"), "flags": flags})
+    result = {"passed": not findings, "findings": findings}
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## AI-7 HyperAtlas deployment links and gates

This PR adds a small governance layer around the AI-7 Québec-Canada Institutional HyperAtlas propagation.

### Included

- `institutional_hyperatlas/DEPLOYMENT_LINKS.md`
- `institutional_hyperatlas/gates/privacy_gate.py`
- `institutional_hyperatlas/gates/license_gate.py`
- `institutional_hyperatlas/VALIDATION_RUNBOOK.md`

### Purpose

This PR links the active propagation surfaces and adds minimal local gates before future ingestion, sync, web, game or cloud expansion.

### Safe-by-design scope

- No workflow changes.
- No cloud deployment.
- No scraping.
- No outreach automation.
- No secrets.
- No personal data collection.

### Next step

A later PR can add schema validation and CI tests that run only local files.
