### PR TITLE
Add CI for AI-7 HyperAtlas no-network validation

### DIFF
--- a/.github/workflows/ai7_hyperatlas_no_network_validation.yml
+++ b/.github/workflows/ai7_hyperatlas_no_network_validation.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run standalone no-network validator
         run: python institutional_hyperatlas/tests/run_no_network_validation.py
 
+      - name: Run dependency-free schema validator
+        run: python institutional_hyperatlas/tests/validate_top64_schemas.py
+
       - name: Assert no generated test artifact is committed
         run: |
           if git status --short | grep -q 'test_generated_top64x5.json'; then

--- a/.github/workflows/ai7_hyperatlas_no_network_validation.yml
+++ b/.github/workflows/ai7_hyperatlas_no_network_validation.yml
@@ -1,0 +1,42 @@
+name: AI-7 HyperAtlas no-network validation
+
+on:
+  pull_request:
+    paths:
+      - 'institutional_hyperatlas/**'
+      - '.github/workflows/ai7_hyperatlas_no_network_validation.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai7-hyperatlas-no-network-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-local-only:
+    name: Validate AI-7 HyperAtlas locally
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run standalone no-network validator
+        run: python institutional_hyperatlas/tests/run_no_network_validation.py
+
+      - name: Assert no generated test artifact is committed
+        run: |
+          if git status --short | grep -q 'test_generated_top64x5.json'; then
+            echo 'Generated test artifact should not be committed.'
+            git status --short
+            exit 1
+          fi

--- a/institutional_hyperatlas/schemas/top64_axes_schema.json
+++ b/institutional_hyperatlas/schemas/top64_axes_schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI-7 QC-CA Top 64^4 axes schema",
+  "type": "object",
+  "required": [
+    "A_institutions_sources",
+    "B_challenges_sectors",
+    "C_ai7_capabilities",
+    "D_actions_governance",
+    "count_per_axis",
+    "total_combinations"
+  ],
+  "properties": {
+    "A_institutions_sources": {"type": "array", "minItems": 64, "maxItems": 64, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "B_challenges_sectors": {"type": "array", "minItems": 64, "maxItems": 64, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "C_ai7_capabilities": {"type": "array", "minItems": 64, "maxItems": 64, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "D_actions_governance": {"type": "array", "minItems": 64, "maxItems": 64, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "count_per_axis": {"const": 64},
+    "total_combinations": {"const": 16777216},
+    "generated_at": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/institutional_hyperatlas/schemas/top64_e_axis_schema.json
+++ b/institutional_hyperatlas/schemas/top64_e_axis_schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI-7 QC-CA Top 64^5 E-axis schema",
+  "type": "object",
+  "required": [
+    "E_dct_proof_prototype_maturity_gates",
+    "count",
+    "axis_name",
+    "axis_role",
+    "total_tensor_size_with_existing_axes"
+  ],
+  "properties": {
+    "E_dct_proof_prototype_maturity_gates": {"type": "array", "minItems": 64, "maxItems": 64, "items": {"type": "string", "minLength": 1}, "uniqueItems": true},
+    "count": {"const": 64},
+    "axis_name": {"const": "E"},
+    "axis_role": {"type": "string", "minLength": 1},
+    "total_tensor_size_with_existing_axes": {"const": 1073741824}
+  },
+  "additionalProperties": true
+}

--- a/institutional_hyperatlas/tests/SCHEMA_VALIDATION.md
+++ b/institutional_hyperatlas/tests/SCHEMA_VALIDATION.md
@@ -1,0 +1,29 @@
+# AI-7 Top 64 Schema Validation
+
+This layer adds dependency-free schema-style validation for the `64^4` and `64^5` HyperAtlas axes.
+
+## Files
+
+- `institutional_hyperatlas/schemas/top64_axes_schema.json`
+- `institutional_hyperatlas/schemas/top64_e_axis_schema.json`
+- `institutional_hyperatlas/tests/validate_top64_schemas.py`
+
+## Run
+
+```bash
+python institutional_hyperatlas/tests/validate_top64_schemas.py
+```
+
+## Checks
+
+- A/B/C/D axes exist.
+- E axis exists.
+- Every axis has exactly 64 entries.
+- Every axis has unique non-empty string entries.
+- `64^4 = 16,777,216` is exact.
+- `64^5 = 1,073,741,824` is exact.
+- Schema constants match actual tensor counts.
+
+## Why this matters
+
+The HyperAtlas is allowed to generate huge candidate spaces only if its generators remain compact, exact, testable, and governed.

--- a/institutional_hyperatlas/tests/validate_top64_schemas.py
+++ b/institutional_hyperatlas/tests/validate_top64_schemas.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Dependency-free schema-style validation for AI-7 Top 64 axes.
+
+This is intentionally stricter than a loose smoke test and does not require jsonschema.
+It validates the shape, exact counts, uniqueness, and tensor cardinalities.
+"""
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+AXES4 = ROOT / "institutional_hyperatlas/top_64x64x64x64/axes/top_64_axes.json"
+AXIS5 = ROOT / "institutional_hyperatlas/top_64x64x64x64x64/axes/top_64_e_dct_axis.json"
+SCHEMA4 = ROOT / "institutional_hyperatlas/schemas/top64_axes_schema.json"
+SCHEMA5 = ROOT / "institutional_hyperatlas/schemas/top64_e_axis_schema.json"
+
+AXES4_KEYS = [
+    "A_institutions_sources",
+    "B_challenges_sectors",
+    "C_ai7_capabilities",
+    "D_actions_governance",
+]
+AXIS5_KEY = "E_dct_proof_prototype_maturity_gates"
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def validate_axis(values, name):
+    check(isinstance(values, list), f"{name} must be a list")
+    check(len(values) == 64, f"{name} must contain exactly 64 entries")
+    check(len(set(values)) == 64, f"{name} entries must be unique")
+    for index, value in enumerate(values):
+        check(isinstance(value, str), f"{name}[{index}] must be a string")
+        check(value.strip(), f"{name}[{index}] must be non-empty")
+
+
+def main():
+    axes4 = json.loads(AXES4.read_text(encoding="utf-8"))
+    axis5 = json.loads(AXIS5.read_text(encoding="utf-8"))
+    schema4 = json.loads(SCHEMA4.read_text(encoding="utf-8"))
+    schema5 = json.loads(SCHEMA5.read_text(encoding="utf-8"))
+
+    for key in AXES4_KEYS:
+        check(key in axes4, f"Missing key in 64^4 axes: {key}")
+        validate_axis(axes4[key], key)
+    check(axes4.get("count_per_axis") == 64, "count_per_axis must be 64")
+    check(axes4.get("total_combinations") == 64**4, "64^4 total mismatch")
+
+    check(AXIS5_KEY in axis5, f"Missing key in E-axis: {AXIS5_KEY}")
+    validate_axis(axis5[AXIS5_KEY], AXIS5_KEY)
+    check(axis5.get("count") == 64, "E-axis count must be 64")
+    check(axis5.get("axis_name") == "E", "axis_name must be E")
+    check(axis5.get("total_tensor_size_with_existing_axes") == 64**5, "64^5 total mismatch")
+
+    check(schema4["properties"]["count_per_axis"]["const"] == 64, "schema4 count const mismatch")
+    check(schema4["properties"]["total_combinations"]["const"] == 64**4, "schema4 total const mismatch")
+    check(schema5["properties"]["count"]["const"] == 64, "schema5 count const mismatch")
+    check(schema5["properties"]["total_tensor_size_with_existing_axes"]["const"] == 64**5, "schema5 total const mismatch")
+
+    print("AI-7 Top64 schema validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## AI-7 HyperAtlas no-network CI

This PR adds the first bounded GitHub Actions validation layer for the AI-7 Québec-Canada HyperAtlas chain.

### Included

- `.github/workflows/ai7_hyperatlas_no_network_validation.yml`

### What it does

- Runs only on PRs touching `institutional_hyperatlas/**` or this workflow.
- Uses `permissions: contents: read`.
- Uses `persist-credentials: false` at checkout.
- Runs the standalone local validator:

```bash
python institutional_hyperatlas/tests/run_no_network_validation.py
```

- Fails if the generated test artifact is left in the working tree.

### Safety

- No secrets.
- No deployment.
- No scraping.
- No outreach automation.
- No remote API ingestion.
- Timeout bounded to 5 minutes.

### Dependency

This PR is based on PR #19 and should follow the PR chain:

```text
PR #14 -> PR #18 -> PR #19 -> this PR
```

It turns the no-network validator into an enforceable CI gate.