### PR TITLE
Wire schema validation into AI-7 no-network CI

### DIFF
--- a/.github/workflows/ai7_hyperatlas_no_network_validation.yml
+++ b/.github/workflows/ai7_hyperatlas_no_network_validation.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run standalone no-network validator
         run: python institutional_hyperatlas/tests/run_no_network_validation.py
 
+      - name: Run dependency-free schema validator
+        run: python institutional_hyperatlas/tests/validate_top64_schemas.py
+
       - name: Assert no generated test artifact is committed
         run: |
           if git status --short | grep -q 'test_generated_top64x5.json'; then


### PR DESCRIPTION
## AI-7 no-network CI + schema gate

This PR wires the dependency-free schema validator from PR #21 into the bounded no-network CI workflow from PR #20.

### Included

- Update `.github/workflows/ai7_hyperatlas_no_network_validation.yml`

### New CI step

```bash
python institutional_hyperatlas/tests/validate_top64_schemas.py
```

### Full local validation path

The CI now runs:

```bash
python institutional_hyperatlas/tests/run_no_network_validation.py
python institutional_hyperatlas/tests/validate_top64_schemas.py
```

### Safety

- `permissions: contents: read`
- `persist-credentials: false`
- no secrets
- no scraping
- no outreach automation
- no cloud deployment
- no remote ingestion
- timeout bounded to 5 minutes

### Dependency chain

```text
PR #14 -> PR #18 -> PR #19 -> PR #20 -> PR #21 -> this PR
```

This converts schema validation from a local script into an enforceable CI gate.