### PR TITLE
Add AI-7 HyperAtlas post-merge canon receipt

### DIFF
--- a/institutional_hyperatlas/POST_MERGE_CANON_RECEIPT.md
+++ b/institutional_hyperatlas/POST_MERGE_CANON_RECEIPT.md
@@ -1,0 +1,78 @@
+# AI-7 Québec-Canada HyperAtlas Post-Merge Canon Receipt
+
+Status: merged into `main` as governed public-preview trunk candidate.
+
+## Main merge commit
+
+```text
+101a3e8e835065a573497e88fdb7dd240f6842ff
+```
+
+## What entered main
+
+- `64^4` institutional opportunity tensor.
+- `64^5` DCT / proof / prototype / maturity extension.
+- Streaming top-k generators.
+- No-network local validation.
+- Dependency-free schema validation.
+- Bounded GitHub Actions validation gate.
+
+## Canonical equations
+
+```text
+Opportunity4(a,b,c,d) = InstitutionSource[a] ⊗ Challenge[b] ⊗ Capability[c] ⊗ Action[d]
+```
+
+```text
+Opportunity5(a,b,c,d,e) = InstitutionSource[a] ⊗ Challenge[b] ⊗ Capability[c] ⊗ Action[d] ⊗ DCTGate[e]
+```
+
+```text
+64^4 = 16,777,216
+64^5 = 1,073,741,824
+```
+
+## Promotion rule
+
+```text
+Promote(edge5) = 1 iff Score > theta and PrivacyOK and LicenseOK and HumanReviewOK and DCTReady
+```
+
+## Safety invariants preserved
+
+- No scraping introduced.
+- No outreach automation introduced.
+- No secret handling introduced.
+- No production cloud deployment introduced.
+- CI permissions are read-only.
+- Checkout does not persist credentials.
+- Validation is local and no-network.
+
+## Known blocker
+
+The merge commit currently has mixed Vercel statuses:
+
+- `Vercel – tristan-tardif-morency-tfug`: success.
+- `Vercel – tristan-tardif-morency-tfug-s881`: failure.
+
+This does not invalidate the HyperAtlas tensor stack, but it blocks full production-stable status until the failing Vercel project is fixed, removed, isolated, or explicitly waived.
+
+## Current canon status
+
+```text
+Stable trunk candidate: yes
+Production stable: not yet
+Public preview governed: yes
+```
+
+## Next promotion steps
+
+1. Resolve or isolate the failing Vercel project.
+2. Confirm the AI-7 no-network validation workflow passes on main.
+3. Add a small release tag or release note after checks are green.
+4. Link this canon receipt from the public README or HyperAtlas index.
+5. Start the next layer: `64^6` only after proof, CI, and governance are stable.
+
+## Canonical phrase
+
+AI-7 HyperAtlas is now in the trunk as a governed generator: it may generate massively, but it must promote rarely, with proof, gates, and rollback paths.


### PR DESCRIPTION
## AI-7 HyperAtlas post-merge canon receipt

This PR adds a canon receipt after the merged HyperAtlas tensor stack entered `main`.

### Included

- `institutional_hyperatlas/POST_MERGE_CANON_RECEIPT.md`

### Records

- Merge commit: `101a3e8e835065a573497e88fdb7dd240f6842ff`
- `64^4` institutional opportunity tensor.
- `64^5` DCT / proof / prototype / maturity extension.
- Streaming top-k generators.
- No-network local validation.
- Dependency-free schema validation.
- Bounded GitHub Actions validation gate.

### Known blocker

The merge commit still has mixed Vercel status:

- `Vercel – tristan-tardif-morency-tfug`: success.
- `Vercel – tristan-tardif-morency-tfug-s881`: failure.

This PR documents that the stack is a governed public-preview trunk candidate, not yet production-stable.

### Safety

- No code execution change.
- No workflow change.
- No cloud deployment.
- No secrets.
- No scraping.
- Documentation only.