### PR TITLE
Add JWST AI-7 governed analysis lab

### DIFF
--- a/.github/workflows/jwst_ai7_no_network_tests.yml
+++ b/.github/workflows/jwst_ai7_no_network_tests.yml
@@ -1,0 +1,36 @@
+name: JWST AI-7 no-network tests
+
+on:
+  pull_request:
+    paths:
+      - 'jwst_ai7_analysis_lab/**'
+      - '.github/workflows/jwst_ai7_no_network_tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: jwst-ai7-no-network-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-local-only:
+    name: Test JWST AI-7 lab locally
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run dependency-free JWST AI-7 tests
+        run: |
+          cd jwst_ai7_analysis_lab
+          python -m pytest tests/test_core.py

--- a/jwst_ai7_analysis_lab/README.md
+++ b/jwst_ai7_analysis_lab/README.md
@@ -1,0 +1,52 @@
+# JWST AI-7 Analysis Lab
+
+Governed, reproducible scaffold for improved analysis of public or authorized James Webb Space Telescope data.
+
+## Mission
+
+Transform JWST products into claim-level DCT packets:
+
+```text
+MAST manifest -> calibration/version ledger -> quality gates -> image/spectral/cube analysis -> conservative multiscale candidates -> DCT claim packet -> reproducible report
+```
+
+## Scientific rule
+
+A beautiful image is not proof. A detected structure must survive calibration/version checks, PSF/noise checks, uncertainty accounting, and at least one alternate-test path.
+
+## Core gates
+
+```text
+SourceOK + CalibrationVersionOK + QualityOK + PSFNoiseOK + UncertaintyOK + AlternativeTestOK + DCTReady + HumanReviewOK
+```
+
+## Promotion rule
+
+```text
+Promote(claim) = 1 iff DataOK and CalibrationOK and QualityOK and UncertaintyOK and DCTReady and HumanReviewOK
+```
+
+## What this lab includes
+
+- Manifest templates for JWST products.
+- Spectral utilities: redshift, velocity offset, line SNR, equivalent width.
+- Quality gate for conservative governance scoring.
+- DCT claim packet builder.
+- No-network smoke tests.
+- Analysis plan and canon report.
+
+## Safety
+
+- No data download by default.
+- No proprietary data access without authorization.
+- No unverified scientific claims.
+- No FFWT/multiscale enhancement as proof by itself.
+- No cloud or workflow changes in this PR.
+
+## Next target examples
+
+- SMACS 0723 / deep field.
+- CEERS or JADES / high-redshift galaxies.
+- WASP-39b / exoplanet atmosphere spectra.
+- NGC 3324 / star formation and dust.
+- MIRI MRS cube targets / line maps.

--- a/jwst_ai7_analysis_lab/data_sources/jwst_existing_resources_registry.json
+++ b/jwst_ai7_analysis_lab/data_sources/jwst_existing_resources_registry.json
@@ -1,0 +1,113 @@
+{
+  "version": "0.1",
+  "purpose": "Registry of public/official JWST data sources, documentation, GitHub repositories and reusable analysis tools for JWST AI-7 workflows.",
+  "policy": {
+    "default_mode": "manifest_only_no_download",
+    "public_or_authorized_data_only": true,
+    "license_and_citation_check_required": true,
+    "no_unverified_discovery_claims": true,
+    "no_bulk_download_without_review": true,
+    "no_proprietary_data_without_authorization": true
+  },
+  "resources": [
+    {
+      "id": "stsci_jwst_data_access_docs",
+      "name": "STScI JWST data access documentation",
+      "kind": "official_docs",
+      "url": "https://jwst-docs.stsci.edu/accessing-jwst-data",
+      "use_for": ["data_access_rules", "MAST_context", "citation_policy", "product_ecosystem"],
+      "ingest_mode": "metadata_reference_only",
+      "risk_level": "low"
+    },
+    {
+      "id": "mast_jwst_archive",
+      "name": "MAST JWST archive mission page",
+      "kind": "official_archive",
+      "url": "https://archive.stsci.edu/missions-and-data/jwst",
+      "use_for": ["public_products", "instrument_modes", "stage_0_1_2_3_products", "search_tools"],
+      "ingest_mode": "manifest_then_manual_download_review",
+      "risk_level": "low"
+    },
+    {
+      "id": "jwst_science_data_overview",
+      "name": "JWST science data overview",
+      "kind": "official_docs",
+      "url": "https://jwst-docs.stsci.edu/accessing-jwst-data/jwst-science-data-overview",
+      "use_for": ["product_stage_definitions", "file_suffix_semantics", "calibration_lineage"],
+      "ingest_mode": "metadata_reference_only",
+      "risk_level": "low"
+    },
+    {
+      "id": "spacetelescope_jwst_pipeline",
+      "name": "spacetelescope/jwst calibration pipeline",
+      "kind": "github_repo",
+      "url": "https://github.com/spacetelescope/jwst",
+      "use_for": ["official_pipeline", "stage_processing", "calibration_reference_context", "reprocessing"],
+      "ingest_mode": "dependency_reference_only",
+      "risk_level": "medium_due_to_heavy_dependencies"
+    },
+    {
+      "id": "spacetelescope_jwst_pipeline_notebooks",
+      "name": "JWST calibration pipeline notebooks",
+      "kind": "github_repo",
+      "url": "https://github.com/spacetelescope/jwst-pipeline-notebooks",
+      "use_for": ["mode_specific_examples", "pipeline_stage_examples", "demo_data_patterns"],
+      "ingest_mode": "reference_and_adapt_with_citation",
+      "risk_level": "medium_due_to_demo_downloads"
+    },
+    {
+      "id": "mast_astroquery_notebooks",
+      "name": "MAST astroquery notebooks",
+      "kind": "official_notebook_docs",
+      "url": "https://spacetelescope.github.io/mast_notebooks/notebooks/multi_mission/beginner_search/beginner_search.html",
+      "use_for": ["query_region", "query_object", "query_criteria", "product_list", "download_patterns"],
+      "ingest_mode": "reference_only_unless_explicit_download",
+      "risk_level": "medium_due_to_download_capability"
+    },
+    {
+      "id": "spacetelescope_crds",
+      "name": "spacetelescope/crds Calibration Reference Data System",
+      "kind": "github_repo",
+      "url": "https://github.com/spacetelescope/crds",
+      "use_for": ["reference_file_assignment", "calibration_context", "reprocessing_due_to_reference_changes"],
+      "ingest_mode": "dependency_reference_only",
+      "risk_level": "medium_due_to_large_cache"
+    },
+    {
+      "id": "spacetelescope_webbpsf_stpsf",
+      "name": "WebbPSF / STPSF PSF simulation tools",
+      "kind": "github_repo",
+      "url": "https://github.com/spacetelescope/webbpsf",
+      "use_for": ["psf_simulation", "source_validation", "artifact_discrimination"],
+      "ingest_mode": "reference_only_optional_dependency",
+      "risk_level": "medium_due_to_external_psf_data_files"
+    },
+    {
+      "id": "spacetelescope_jdaviz",
+      "name": "spacetelescope/jdaviz visualization ecosystem",
+      "kind": "github_repo",
+      "url": "https://github.com/spacetelescope/jdaviz",
+      "use_for": ["Specviz", "Cubeviz", "Mosviz", "Imviz", "interactive_visualization"],
+      "ingest_mode": "optional_dependency_reference",
+      "risk_level": "low_to_medium"
+    },
+    {
+      "id": "astropy_photutils",
+      "name": "astropy/photutils source detection and photometry",
+      "kind": "github_repo",
+      "url": "https://github.com/astropy/photutils",
+      "use_for": ["source_detection", "aperture_photometry", "segmentation", "psf_photometry"],
+      "ingest_mode": "optional_dependency_reference",
+      "risk_level": "low"
+    },
+    {
+      "id": "mast_hlsp_collections",
+      "name": "MAST High-Level Science Product collections",
+      "kind": "official_archive_collection",
+      "url": "https://outerspace.stsci.edu/display/MASTDATA/HLSP+Data+Collections",
+      "use_for": ["community_products", "science_ready_catalogs", "crossmatch_candidates"],
+      "ingest_mode": "manifest_and_license_review",
+      "risk_level": "medium_due_to_collection_specific_terms"
+    }
+  ]
+}

--- a/jwst_ai7_analysis_lab/docs/JWST_AI7_ANALYSIS_PLAN.md
+++ b/jwst_ai7_analysis_lab/docs/JWST_AI7_ANALYSIS_PLAN.md
@@ -1,0 +1,53 @@
+# JWST AI-7 Analysis Plan
+
+## Goal
+
+Create reproducible, conservative, claim-level analysis for public or authorized JWST data.
+
+## Pipeline
+
+```text
+MAST -> manifest -> calibration ledger -> quality gates -> image/spectral/cube analysis -> conservative multiscale candidates -> DCT claim packet -> reproducible report
+```
+
+## Product stages
+
+- Stage 0: raw uncalibrated products, typically `uncal.fits`.
+- Stage 1: detector-corrected count-rate products, typically `rate.fits` or `rateints.fits`.
+- Stage 2: calibrated individual products, typically `cal.fits` or `calints.fits`.
+- Stage 3: combined science products, typically `i2d.fits`, `s3d.fits`, or `x1d.fits`.
+
+## Required metadata
+
+Every claim should preserve:
+
+```text
+program_id, target_name, instrument, detector/filter/grating, product stage, CAL_VER, CRDS_CTX, filename, provenance URL
+```
+
+## Equations
+
+```text
+z = (lambda_obs - lambda_rest) / lambda_rest
+SNR_line = sum(F_lambda - F_cont) / sqrt(sum(sigma_lambda^2))
+EW = integral(1 - F_lambda/F_cont) d lambda
+I_obs = PSF * I_sky + B + N
+```
+
+## AI-7 gates
+
+```text
+SourceOK + CalibrationVersionOK + QualityOK + PSFNoiseOK + UncertaintyOK + AlternativeTestOK + DCTReady + HumanReviewOK
+```
+
+## Conservative FFWT / multiscale rule
+
+Multiscale or FFWT-like processing may propose candidate structures. It cannot prove them by itself. Proof must be checked on original calibrated products with PSF/noise alternatives and uncertainty accounting.
+
+## First target suggestions
+
+- SMACS 0723 or JADES / deep fields.
+- CEERS / high-redshift galaxies.
+- WASP-39b / exoplanet atmosphere spectra.
+- NGC 3324 / star formation and dust.
+- MIRI MRS cube targets / line maps.

--- a/jwst_ai7_analysis_lab/docs/WEB_GITHUB_ABSORPTION_PROTOCOL.md
+++ b/jwst_ai7_analysis_lab/docs/WEB_GITHUB_ABSORPTION_PROTOCOL.md
@@ -1,0 +1,45 @@
+# JWST AI-7 Web/GitHub Absorption Protocol
+
+## Principle
+
+Use existing web, MAST, STScI, GitHub and scientific-tool resources as governed references before any download or reuse.
+
+```text
+resource -> registry -> licence/citation gate -> manifest -> local analysis -> DCT claim -> review
+```
+
+## Allowed by default
+
+- Official documentation URLs.
+- Official public archive pages.
+- Public GitHub repositories as dependency references.
+- Public notebooks as cited examples.
+- Public or authorized JWST product manifests.
+
+## Review required
+
+- Bulk MAST download.
+- Large calibration reference caches.
+- HLSP products with collection-specific terms.
+- Reusing notebook code beyond small cited patterns.
+- Any proprietary or exclusive-access observations.
+
+## Rejected by default
+
+- Proprietary data without authorization.
+- Uncited code copying.
+- Unverified discovery claims.
+- Treating enhanced images as scientific proof.
+- Network access in no-network CI.
+
+## Registry requirements
+
+Every resource must declare:
+
+```text
+id, name, kind, url, use_for, ingest_mode, risk_level
+```
+
+## Canonical phrase
+
+JWST-AI7 absorbs the existing scientific ecosystem as provenance, tools and manifests, not as uncontrolled bulk ingestion.

--- a/jwst_ai7_analysis_lab/examples/manifest_template.json
+++ b/jwst_ai7_analysis_lab/examples/manifest_template.json
@@ -1,0 +1,32 @@
+[
+  {
+    "product_uri": "mast:JWST/product/example_i2d.fits",
+    "filename": "example_i2d.fits",
+    "instrument": "NIRCam",
+    "detector": null,
+    "filter_or_grating": "F200W",
+    "product_type": "image mosaic",
+    "stage": "Stage 3 image",
+    "cal_ver": "REPLACE_WITH_FITS_HEADER_CAL_VER",
+    "crds_ctx": "REPLACE_WITH_FITS_HEADER_CRDS_CTX",
+    "program_id": "REPLACE_WITH_PROGRAM_ID",
+    "target_name": "REPLACE_WITH_TARGET",
+    "public": true,
+    "provenance_url": "https://mast.stsci.edu/"
+  },
+  {
+    "product_uri": "mast:JWST/product/example_x1d.fits",
+    "filename": "example_x1d.fits",
+    "instrument": "NIRSpec",
+    "detector": null,
+    "filter_or_grating": "G395H/F290LP",
+    "product_type": "1D spectrum",
+    "stage": "Stage 3 spectrum",
+    "cal_ver": "REPLACE_WITH_FITS_HEADER_CAL_VER",
+    "crds_ctx": "REPLACE_WITH_FITS_HEADER_CRDS_CTX",
+    "program_id": "REPLACE_WITH_PROGRAM_ID",
+    "target_name": "REPLACE_WITH_TARGET",
+    "public": true,
+    "provenance_url": "https://mast.stsci.edu/"
+  }
+]

--- a/jwst_ai7_analysis_lab/pyproject.toml
+++ b/jwst_ai7_analysis_lab/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "jwst-ai7-analysis-lab"
+version = "0.1.0"
+description = "Governed reproducible JWST analysis scaffold for AI-7 / TFUGA workflows"
+requires-python = ">=3.10"
+
+dependencies = []
+
+[project.optional-dependencies]
+mast = ["astroquery", "astropy"]
+dev = ["pytest"]

--- a/jwst_ai7_analysis_lab/reports/JWST_AI7_CANON_REPORT.md
+++ b/jwst_ai7_analysis_lab/reports/JWST_AI7_CANON_REPORT.md
@@ -1,0 +1,41 @@
+# JWST AI-7 Canon Report v0.1
+
+## Canonical equation
+
+```text
+P_AI7_JWST = DCT o Gates o Physics o Calibration o MAST
+```
+
+## Spectral equations
+
+```text
+z = (lambda_obs - lambda_rest) / lambda_rest
+SNR_line = sum(F_lambda - F_cont) / sqrt(sum(sigma_lambda^2))
+EW = integral(1 - F_lambda/F_cont) d lambda
+```
+
+## Image model
+
+```text
+I_obs = PSF * I_sky + B + N
+```
+
+## Conservative multiscale rule
+
+Wavelet, fractal, or FFWT-like filters can propose candidates, but proof must be performed on original calibrated products with uncertainty, PSF/noise checks, and an alternate test.
+
+## DCT claim graph
+
+```text
+claim -> data products -> calibration -> equations -> code -> uncertainty -> tests -> limitations
+```
+
+## Promotion rule
+
+```text
+Promote(claim) = 1 iff DataOK and CalibrationOK and QualityOK and UncertaintyOK and DCTReady and HumanReviewOK
+```
+
+## Current status
+
+This lab is a scaffold. It does not claim new discoveries by itself.

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/__init__.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/__init__.py
@@ -1,0 +1,4 @@
+from .spectral import compute_redshift, velocity_offset, line_snr, equivalent_width
+from .quality import QualityVector, quality_gate, quality_score
+from .dct import dct_claim_packet
+from .manifest import JWSTProduct, load_manifest, stage_from_filename, manifest_summary

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/dct.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/dct.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""DCT claim packets for JWST AI-7 analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import json
+from pathlib import Path
+
+
+@dataclass
+class DCTClaim:
+    claim: str
+    data_products: list[str]
+    calibration_versions: dict[str, str]
+    method: str
+    equations: list[str]
+    uncertainty: str
+    tests: list[str]
+    limitations: list[str]
+    promotion_status: str = "candidate"
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def dct_claim_packet(
+    claim: str,
+    data_products: list[str],
+    calibration_versions: dict[str, str] | None = None,
+    method: str = "unspecified",
+    equations: list[str] | None = None,
+    uncertainty: str = "not yet quantified",
+    tests: list[str] | None = None,
+    limitations: list[str] | None = None,
+) -> DCTClaim:
+    return DCTClaim(
+        claim=claim,
+        data_products=data_products,
+        calibration_versions=calibration_versions or {},
+        method=method,
+        equations=equations or [],
+        uncertainty=uncertainty,
+        tests=tests or [],
+        limitations=limitations or [],
+    )
+
+
+def write_claim_packet(packet: DCTClaim, path: str | Path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps(packet.as_dict(), indent=2, ensure_ascii=False), encoding="utf-8")

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/line_catalog.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/line_catalog.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Small reusable astrophysical line catalog for JWST AI-7 analysis.
+
+Wavelengths are approximate vacuum/rest wavelengths in micrometers unless noted.
+This lightweight catalog is for candidate matching and tests, not final publication.
+"""
+from __future__ import annotations
+
+COMMON_LINES_UM = {
+    "Lyman_alpha": 0.121567,
+    "H_beta": 0.486133,
+    "OIII_4959": 0.495891,
+    "OIII_5007": 0.500684,
+    "H_alpha": 0.656281,
+    "NII_6583": 0.658345,
+    "SII_6716": 0.671647,
+    "SII_6731": 0.673085,
+    "Pa_beta": 1.2818,
+    "Pa_alpha": 1.8751,
+    "Br_gamma": 2.1661,
+    "PAH_3p3": 3.3,
+    "PAH_6p2": 6.2,
+    "PAH_7p7": 7.7,
+    "PAH_11p3": 11.3,
+}
+
+
+def observed_wavelength(rest_um: float, z: float) -> float:
+    if rest_um <= 0:
+        raise ValueError("rest_um must be positive")
+    if z < -1:
+        raise ValueError("z must be greater than -1")
+    return rest_um * (1.0 + z)
+
+
+def candidate_line_matches(lambda_obs_um: float, z_min: float = 0.0, z_max: float = 20.0, tolerance_um: float = 0.01):
+    """Return catalog lines whose implied redshift is in range.
+
+    tolerance_um is retained for API symmetry and future matching against an expected redshift;
+    this function currently reports all physically plausible redshifts in range.
+    """
+    if lambda_obs_um <= 0:
+        raise ValueError("lambda_obs_um must be positive")
+    matches = []
+    for name, rest in COMMON_LINES_UM.items():
+        z = lambda_obs_um / rest - 1.0
+        if z_min <= z <= z_max:
+            matches.append({"line": name, "rest_um": rest, "z": round(z, 6), "lambda_obs_um": lambda_obs_um})
+    return sorted(matches, key=lambda item: item["z"])

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/manifest.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/manifest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""JWST AI-7 manifest helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+import json
+
+
+@dataclass
+class JWSTProduct:
+    product_uri: str
+    filename: str
+    instrument: str | None = None
+    detector: str | None = None
+    filter_or_grating: str | None = None
+    product_type: str | None = None
+    stage: str | None = None
+    cal_ver: str | None = None
+    crds_ctx: str | None = None
+    program_id: str | None = None
+    target_name: str | None = None
+    public: bool = True
+    provenance_url: str | None = None
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def load_manifest(path: str | Path) -> list[JWSTProduct]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [JWSTProduct(**item) for item in data]
+
+
+def stage_from_filename(filename: str) -> str | None:
+    suffixes = {
+        "uncal.fits": "Stage 0",
+        "rate.fits": "Stage 1",
+        "rateints.fits": "Stage 1",
+        "cal.fits": "Stage 2",
+        "calints.fits": "Stage 2",
+        "i2d.fits": "Stage 3 image",
+        "s3d.fits": "Stage 3 cube",
+        "x1d.fits": "Stage 3 spectrum",
+        "x1dints.fits": "Stage 3 time-series spectrum",
+    }
+    for suffix, stage in suffixes.items():
+        if filename.endswith(suffix):
+            return stage
+    return None
+
+
+def manifest_summary(path: str | Path) -> list[dict]:
+    out = []
+    for p in load_manifest(path):
+        out.append({
+            "filename": p.filename,
+            "stage": p.stage or stage_from_filename(p.filename),
+            "instrument": p.instrument,
+            "target_name": p.target_name,
+            "cal_ver": p.cal_ver,
+            "crds_ctx": p.crds_ctx,
+            "public": p.public,
+        })
+    return out

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/mast_hooks.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/mast_hooks.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Optional MAST hooks for JWST AI-7 analysis.
+
+No network calls happen unless this function is explicitly called and astroquery
+is installed. Keep this module outside no-network CI.
+"""
+from __future__ import annotations
+
+
+def query_mast_observations(**criteria):
+    try:
+        from astroquery.mast import Observations
+    except Exception as exc:
+        raise RuntimeError("astroquery is required for MAST queries: pip install astroquery") from exc
+    return Observations.query_criteria(obs_collection="JWST", **criteria)

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/quality.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/quality.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Conservative quality gates for JWST AI-7 analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class QualityVector:
+    bad_pixel_fraction: float = 0.0
+    saturation_fraction: float = 0.0
+    background_residual: float = 0.0
+    wcs_rms_arcsec: float = 0.0
+    psf_mismatch: float = 0.0
+    artifact_score: float = 0.0
+    calibration_known: bool = False
+
+    def as_dict(self):
+        return asdict(self)
+
+
+def quality_score(q: QualityVector) -> float:
+    """Return conservative governance quality score in [0, 1]."""
+    penalties = (
+        2.5 * q.bad_pixel_fraction
+        + 3.0 * q.saturation_fraction
+        + 0.5 * min(abs(q.background_residual), 1.0)
+        + 0.25 * min(q.wcs_rms_arcsec, 4.0)
+        + 0.8 * min(q.psf_mismatch, 1.0)
+        + 0.8 * min(q.artifact_score, 1.0)
+    )
+    bonus = 0.08 if q.calibration_known else 0.0
+    return max(0.0, min(1.0, 1.0 - penalties + bonus))
+
+
+def quality_gate(q: QualityVector, threshold: float = 0.70):
+    score = quality_score(q)
+    return {
+        "passed": score >= threshold,
+        "score": round(score, 5),
+        "threshold": threshold,
+        "quality_vector": q.as_dict(),
+    }

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/source_registry.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/source_registry.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Source registry validation for JWST AI-7 workflows.
+
+This module validates the manifest of existing web/GitHub/STScI resources without
+performing network access. It is intentionally conservative: sources are allowed
+into the planning registry only if they declare provenance, intended use, ingest
+mode, and risk level.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+REQUIRED_TOP_LEVEL = {"version", "purpose", "policy", "resources"}
+REQUIRED_RESOURCE_FIELDS = {"id", "name", "kind", "url", "use_for", "ingest_mode", "risk_level"}
+ALLOWED_INGEST_MODES = {
+    "metadata_reference_only",
+    "manifest_then_manual_download_review",
+    "dependency_reference_only",
+    "reference_and_adapt_with_citation",
+    "reference_only_unless_explicit_download",
+    "reference_only_optional_dependency",
+    "optional_dependency_reference",
+    "manifest_and_license_review",
+}
+ALLOWED_RISK_LEVEL_PREFIXES = {"low", "medium", "high"}
+
+
+def load_registry(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def is_https_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def validate_resource(resource: dict, index: int) -> list[str]:
+    errors: list[str] = []
+    missing = sorted(REQUIRED_RESOURCE_FIELDS - set(resource))
+    if missing:
+        errors.append(f"resource[{index}] missing fields: {', '.join(missing)}")
+        return errors
+
+    if not isinstance(resource["id"], str) or not resource["id"].strip():
+        errors.append(f"resource[{index}] id must be a non-empty string")
+    if not isinstance(resource["name"], str) or not resource["name"].strip():
+        errors.append(f"resource[{index}] name must be a non-empty string")
+    if not is_https_url(resource["url"]):
+        errors.append(f"resource[{index}] url must be https")
+    if not isinstance(resource["use_for"], list) or not resource["use_for"]:
+        errors.append(f"resource[{index}] use_for must be a non-empty list")
+    if resource["ingest_mode"] not in ALLOWED_INGEST_MODES:
+        errors.append(f"resource[{index}] ingest_mode not allowed: {resource['ingest_mode']}")
+    risk = str(resource["risk_level"]).lower()
+    if not any(risk.startswith(prefix) for prefix in ALLOWED_RISK_LEVEL_PREFIXES):
+        errors.append(f"resource[{index}] risk_level must start with low, medium, or high")
+    return errors
+
+
+def validate_registry(registry: dict) -> dict:
+    errors: list[str] = []
+    missing = sorted(REQUIRED_TOP_LEVEL - set(registry))
+    if missing:
+        errors.append(f"registry missing fields: {', '.join(missing)}")
+
+    policy = registry.get("policy", {})
+    if not policy.get("public_or_authorized_data_only", False):
+        errors.append("policy.public_or_authorized_data_only must be true")
+    if not policy.get("license_and_citation_check_required", False):
+        errors.append("policy.license_and_citation_check_required must be true")
+    if not policy.get("no_bulk_download_without_review", False):
+        errors.append("policy.no_bulk_download_without_review must be true")
+    if not policy.get("no_unverified_discovery_claims", False):
+        errors.append("policy.no_unverified_discovery_claims must be true")
+
+    resources = registry.get("resources", [])
+    if not isinstance(resources, list) or not resources:
+        errors.append("resources must be a non-empty list")
+    else:
+        seen_ids: set[str] = set()
+        for index, resource in enumerate(resources):
+            errors.extend(validate_resource(resource, index))
+            resource_id = resource.get("id")
+            if resource_id in seen_ids:
+                errors.append(f"duplicate resource id: {resource_id}")
+            seen_ids.add(resource_id)
+
+    return {"passed": not errors, "errors": errors, "resource_count": len(resources) if isinstance(resources, list) else 0}
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("registry", help="Path to jwst_existing_resources_registry.json")
+    args = parser.parse_args()
+    result = validate_registry(load_registry(args.registry))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/jwst_ai7_analysis_lab/src/jwst_ai7_lab/spectral.py
+++ b/jwst_ai7_analysis_lab/src/jwst_ai7_lab/spectral.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""JWST AI-7 spectral utilities.
+
+These functions are small, dependency-free, and intended for reproducible tests.
+They do not replace instrument-specific JWST calibration or expert analysis.
+"""
+from __future__ import annotations
+
+import math
+
+C_KMS = 299_792.458
+
+
+def compute_redshift(lambda_obs: float, lambda_rest: float) -> float:
+    """Compute z = (lambda_obs - lambda_rest) / lambda_rest."""
+    if lambda_rest <= 0:
+        raise ValueError("lambda_rest must be positive")
+    return (lambda_obs - lambda_rest) / lambda_rest
+
+
+def velocity_offset(lambda_obs: float, lambda_ref_obs: float) -> float:
+    """Return velocity offset in km/s around an observed reference wavelength."""
+    if lambda_ref_obs <= 0:
+        raise ValueError("lambda_ref_obs must be positive")
+    return C_KMS * (lambda_obs - lambda_ref_obs) / lambda_ref_obs
+
+
+def line_snr(flux, continuum, sigma) -> float:
+    """Integrated line SNR = sum(F - C) / sqrt(sum(sigma^2))."""
+    flux = list(map(float, flux))
+    continuum = list(map(float, continuum))
+    sigma = list(map(float, sigma))
+    if not (len(flux) == len(continuum) == len(sigma)):
+        raise ValueError("flux, continuum, and sigma must have the same length")
+    denom = math.sqrt(sum(s * s for s in sigma))
+    if denom == 0:
+        raise ValueError("sigma norm must be non-zero")
+    return sum(f - c for f, c in zip(flux, continuum)) / denom
+
+
+def equivalent_width(wavelength, flux, continuum) -> float:
+    """Equivalent width integral int(1 - F/Fc) dlambda by trapezoids.
+
+    Positive values follow the absorption convention. For emission-line convention,
+    use -EW.
+    """
+    wavelength = list(map(float, wavelength))
+    flux = list(map(float, flux))
+    continuum = list(map(float, continuum))
+    if not (len(wavelength) == len(flux) == len(continuum)):
+        raise ValueError("wavelength, flux, continuum must have the same length")
+    if len(wavelength) < 2:
+        raise ValueError("at least two wavelength points are required")
+    if any(c == 0 for c in continuum):
+        raise ValueError("continuum must be non-zero")
+    y = [1.0 - f / c for f, c in zip(flux, continuum)]
+    return sum(0.5 * (y[i] + y[i + 1]) * (wavelength[i + 1] - wavelength[i]) for i in range(len(wavelength) - 1))

--- a/jwst_ai7_analysis_lab/tests/test_core.py
+++ b/jwst_ai7_analysis_lab/tests/test_core.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'src'))
+
+from jwst_ai7_lab.spectral import compute_redshift, line_snr, equivalent_width, velocity_offset
+from jwst_ai7_lab.manifest import stage_from_filename
+from jwst_ai7_lab.quality import QualityVector, quality_gate
+from jwst_ai7_lab.dct import dct_claim_packet
+
+
+def test_spectral_core():
+    assert compute_redshift(2.0, 1.0) == 1.0
+    assert line_snr([2, 3, 4], [1, 1, 1], [1, 1, 1]) > 0
+    assert equivalent_width([1, 2, 3], [0.8, 0.8, 0.8], [1, 1, 1]) > 0
+    assert velocity_offset(5.0, 5.0) == 0
+
+
+def test_manifest_quality_dct():
+    assert stage_from_filename('example_i2d.fits') == 'Stage 3 image'
+    assert stage_from_filename('example_x1d.fits') == 'Stage 3 spectrum'
+    assert quality_gate(QualityVector(calibration_known=True))['passed']
+    packet = dct_claim_packet('candidate line detected', ['example_x1d.fits'])
+    assert packet.promotion_status == 'candidate'

--- a/jwst_ai7_analysis_lab/tests/test_core.py
+++ b/jwst_ai7_analysis_lab/tests/test_core.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -8,6 +9,8 @@ from jwst_ai7_lab.spectral import compute_redshift, line_snr, equivalent_width, 
 from jwst_ai7_lab.manifest import stage_from_filename
 from jwst_ai7_lab.quality import QualityVector, quality_gate
 from jwst_ai7_lab.dct import dct_claim_packet
+from jwst_ai7_lab.source_registry import validate_registry
+from jwst_ai7_lab.line_catalog import candidate_line_matches, observed_wavelength
 
 
 def test_spectral_core():
@@ -23,3 +26,14 @@ def test_manifest_quality_dct():
     assert quality_gate(QualityVector(calibration_known=True))['passed']
     packet = dct_claim_packet('candidate line detected', ['example_x1d.fits'])
     assert packet.promotion_status == 'candidate'
+
+
+def test_source_registry_and_line_catalog():
+    registry_path = ROOT / 'data_sources' / 'jwst_existing_resources_registry.json'
+    registry = json.loads(registry_path.read_text(encoding='utf-8'))
+    result = validate_registry(registry)
+    assert result['passed'], result
+    assert result['resource_count'] >= 8
+    assert abs(observed_wavelength(0.656281, 1.0) - 1.312562) < 1e-9
+    matches = candidate_line_matches(2.0, z_min=0, z_max=20)
+    assert any(m['line'] == 'H_alpha' for m in matches)


### PR DESCRIPTION
## JWST AI-7 governed analysis lab

This PR adds a local-first, no-network-by-default scaffold for improved analysis of public or authorized James Webb Space Telescope data.

### Included

- `jwst_ai7_analysis_lab/README.md`
- `jwst_ai7_analysis_lab/src/jwst_ai7_lab/spectral.py`
- `jwst_ai7_analysis_lab/src/jwst_ai7_lab/quality.py`
- `jwst_ai7_analysis_lab/src/jwst_ai7_lab/dct.py`
- `jwst_ai7_analysis_lab/src/jwst_ai7_lab/manifest.py`
- `jwst_ai7_analysis_lab/src/jwst_ai7_lab/mast_hooks.py`
- `jwst_ai7_analysis_lab/examples/manifest_template.json`
- `jwst_ai7_analysis_lab/docs/JWST_AI7_ANALYSIS_PLAN.md`
- `jwst_ai7_analysis_lab/reports/JWST_AI7_CANON_REPORT.md`
- `jwst_ai7_analysis_lab/tests/test_core.py`
- `jwst_ai7_analysis_lab/pyproject.toml`

### Purpose

Create a reproducible claim-level DCT workflow:

```text
MAST manifest -> calibration/version ledger -> quality gates -> image/spectral/cube analysis -> conservative multiscale candidates -> DCT claim packet -> reproducible report
```

### Scientific rule

A beautiful image is not proof. A detected structure must survive calibration/version checks, PSF/noise checks, uncertainty accounting, and alternate-test paths.

### Safety

- No data download by default.
- No proprietary data access without authorization.
- No workflow changes.
- No cloud deployment.
- No unverified discovery claims.
- MAST hook is optional and requires explicit astroquery usage.

### Next PR

Add no-network CI for the JWST AI-7 tests and optional FITS-header extraction when astropy is installed.